### PR TITLE
[ FIX 🛠️ ] :  Incompatibility Between Compile SDK and AGP Versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.gdgevents.gdgeventsapp"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.gdgevents.gdgeventsapp"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.0"
+agp = "8.5.2"
 kotlin = "1.9.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"


### PR DESCRIPTION
## Description

This PR resolves the compatibility issue between the compile SDK version and the Android Gradle Plugin (AGP) version. To align with the latest stable releases, we are updating the project to support SDK 35.

This ensures the project remains up-to-date and compatible with the latest tools and libraries, improving stability and maintainability.

---

## Changes Made
List the changes introduced in this pull request:
- Updated the compile SDK version to 35.
- Ensured compatibility with the latest stable AGP version.
- Verified that all dependencies and configurations align with the updated SDK and AGP versions.

---

## Checklist
Please ensure the following tasks are completed:

- [ ] Unit tests are included for the new functionality (if applicable).
- [x] Code has been properly documented.
- [x] Changes have been tested and verified.
