### PR TITLE
Added project dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,13 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
+
+    // Added plugins
+    alias(libs.plugins.dagger.hilt.android)
+    alias(libs.plugins.kapt)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.protobuf)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -40,7 +47,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
+        kotlinCompilerExtensionVersion = "1.5.13"
     }
     packaging {
         resources {
@@ -66,4 +73,94 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+
+    // Hilt - dependency injection
+    implementation(libs.hilt.android)
+    // hilt kapt - annotation processor — hilt ksp is in alpha
+    kapt(libs.hilt.compiler)
+
+    // Retrofit - make type safe requests
+    implementation(libs.retrofit)
+    // okhttp - fire http calls
+    implementation(libs.okhttp)
+    // logging interceptor - log calls for debugging
+    implementation(libs.logging.interceptor)
+    // converter - make retrofit use serialization json
+    implementation(libs.converter.kotlinx.serialization)
+    // JSON - serialize Kotlin objects <-> JSON
+    implementation(libs.kotlinx.serialization.json)
+
+    // Coil - asynchronous image loading
+    implementation(libs.coil.compose)
+
+    // datastore - make type safe local storage
+    implementation(libs.androidx.datastore)
+    // protobuf - serialize Kotlin objects <-> protobuf schema
+    implementation(libs.protobuf.kotlin.lite)
+
+    // room - local database
+    implementation(libs.androidx.room.runtime)
+    // room ksp - annotation processor
+    ksp(libs.androidx.room.compiler)
+    // room - coroutine support
+    implementation(libs.androidx.room.ktx)
+
+    // mockk unit tests
+    testImplementation(libs.mockk.android)
+    // mockk instrumented tests
+    androidTestImplementation(libs.mockk.android)
+    // kotlin coroutines tests
+    testImplementation(libs.kotlinx.coroutines.test)
+
+    // collect as state with lifecycle
+    implementation(libs.androidx.lifecycle.runtime.compose)
+
+    // adaptive navigation - get window info
+    implementation(libs.androidx.adaptive.navigation.android)
+    // navigation suite scaffold - make adaptive navigation
+    implementation(libs.androidx.material3.adaptive.navigation.suite)
+
+    // compose nav host & type safe navigation
+    implementation(libs.androidx.navigation.compose)
+    // hilt view model injection
+    implementation(libs.androidx.hilt.navigation.compose)
+
+    // splash screen - backwards compatibility
+    implementation(libs.androidx.core.splashscreen)
+
+    // work manager
+    implementation(libs.androidx.work.runtime.ktx)
+    // hilt work manager injection
+    implementation(libs.androidx.hilt.work)
+    // hilt kapt work manager
+    kapt(libs.androidx.hilt.compiler)
+}
+
+// protobuf plugin
+protobuf {
+    // proto compiler
+    protoc {
+        artifact = libs.protobuf.protoc.get().toString()
+    }
+    // plugin instructions
+    generateProtoTasks {
+        all().forEach { task ->
+            task.builtins {
+                // make java files
+                register("java") {
+                    option("lite")
+                }
+                // make kotlin DSL on top of java files
+                register("kotlin") {
+                    option("lite")
+                }
+            }
+        }
+    }
+}
+
+// kapt plugin
+kapt {
+    // improve type inference accuracy
+    correctErrorTypes = true
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,11 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
+
+    // Added plugins
+    alias(libs.plugins.dagger.hilt.android) apply false
+    alias(libs.plugins.kapt) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.protobuf) apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,34 @@
 [versions]
 agp = "8.5.2"
-kotlin = "1.9.0"
+kotlin = "1.9.23"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.9.3"
-composeBom = "2024.04.01"
+composeBom = "2024.05.00"
+
+#-Added versions
+hilt = "2.53.1"
+coilCompose = "3.0.4"
+navigationCompose = "2.8.5"
+retrofit = "2.11.0"
+okhttp = "4.12.0"
+converterKotlinxSerialization = "2.11.0"
+datastore = "1.1.1"
+kotlinxSerializationJson = "1.7.3"
+protobufKotlinLite = "4.26.1"
+protobuf = "0.9.4"
+room = "2.6.1"
+ksp = "1.9.23-1.0.20"
+mockkAndroid = "1.13.11"
+kotlinxCoroutinesTest = "1.9.0"
+navigationSuite = "1.3.1"
+adaptiveNavigation = "1.0.0"
+hiltAndroidx = "1.2.0"
+coreSplashscreen = "1.0.1"
+workRuntimeKtx = "2.10.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -25,7 +46,40 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 
+#-Added dependencies
+hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
+hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
+retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "datastore" }
+converter-kotlinx-serialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "converterKotlinxSerialization" }
+protobuf-kotlin-lite = { module = "com.google.protobuf:protobuf-kotlin-lite", version.ref = "protobufKotlinLite" }
+protobuf-protoc = { module = "com.google.protobuf:protoc", version.ref = "protobufKotlinLite" }
+androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
+androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
+mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockkAndroid" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycleRuntimeKtx" }
+androidx-material3-adaptive-navigation-suite = { module = "androidx.compose.material3:material3-adaptive-navigation-suite", version.ref = "navigationSuite" }
+androidx-adaptive-navigation-android = { module = "androidx.compose.material3.adaptive:adaptive-navigation-android", version.ref = "adaptiveNavigation" }
+androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltAndroidx" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
+androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "coreSplashscreen" }
+androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workRuntimeKtx" }
+androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "hiltAndroidx" }
+androidx-hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "hiltAndroidx" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 
+#-Added plugins
+dagger-hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+protobuf = { id = "com.google.protobuf", version.ref = "protobuf" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
## Description

This **PR** adds dependencies needed for the project and updates kotlin version to **1.9.23** to fix build issues with kapt.
It uses kapt with hilt because dagger’s ksp support is currently in alpha.

This ensures the project uses the latest tools and libraries, improving stability and maintainability.

---

## Changes Made

### added dependencies for : 

* Hilt & kapt
* Retrofit & Okhttp & kotlinx Json
* Coil
* Proto datastore
* Room & ksp
* mockk & courotines testing
* compose navigation & hilt view model
* splash screen
* work manager

---

## Screenshots

> Not applicable.

---

## Checklist

Please ensure the following tasks are completed:

- [ ] Unit tests are included for the new functionality (if applicable).
- [x] Code has been properly documented.
- [x] Changes have been tested and verified.

---

## Additional Comments

> Add tests as you go.
